### PR TITLE
Fix name pipes in Windows 7

### DIFF
--- a/backup_test.go
+++ b/backup_test.go
@@ -203,7 +203,8 @@ func makeSparseFile() error {
 		FSCTL_SET_ZERO_DATA = 0x000980c8
 	)
 
-	err = syscall.DeviceIoControl(syscall.Handle(f.Fd()), FSCTL_SET_SPARSE, nil, 0, nil, 0, nil, nil)
+	var r uint32
+	err = syscall.DeviceIoControl(syscall.Handle(f.Fd()), FSCTL_SET_SPARSE, nil, 0, nil, 0, &r, nil)
 	if err != nil {
 		return err
 	}

--- a/pipe_test.go
+++ b/pipe_test.go
@@ -540,8 +540,10 @@ func TestMessageReadMode(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if n != 1 {
-			t.Fatal("expected 1: ", n)
+		// Since reading in message mode, pipe read() could read 0 byes and return ERROR_MORE_DATA,
+		// except win32MessageBytePipe Read() considers that a success and eats up the error code.
+		if n != 0 && n != 1 {
+			t.Fatal("expected 0 or 1: ", n)
 		}
 		vmsg = append(vmsg, ch[0])
 	}


### PR DESCRIPTION
dup https://github.com/microsoft/go-winio/pull/174

> https://github.com/microsoft/go-winio/issues/173
> Accept() blocks forever on Windows7, and all tests that rely on Accept() returning fail on Windows 7.
> This commit broke it: bd71ef0
> Windows 7 is behaving differently than Win10.
> The fix is a workaround that used to exist before the breaking commit. I have re-introduced the client connect to ensure pipe instance is created. Not sure if there is a better fix.
> Also, fixed a couple of tests which were failing on Windows 7.